### PR TITLE
-N flag and --plot work with LearnReaction.py

### DIFF
--- a/src/nanoreactor.py
+++ b/src/nanoreactor.py
@@ -15,6 +15,7 @@ from pkg_resources import parse_version
 from scipy.signal import butter, freqz
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
+plt.switch_backend('agg')
 
 ## Names of colors from VMD
 ColorNames = ["blue", "red", "gray", "orange", "yellow", 
@@ -1702,7 +1703,7 @@ class Nanoreactor(Molecule):
         spn = np.mean(np.sum(self.Spins[frame1:frame2+1, atoms], axis=1))
         # Don't add any molecules if the molecule is already neutralized
         if np.abs(chg) < tol:
-            return []
+            return [],[]
         if self.printlvl >= 2: print "Attempting to neutralize atoms %s (charge %+.3f spin %+.3f)" % (commadash(atoms), chg, spn)
         xyz = np.array(self.atom_select(atoms)[frames].xyzs)
         


### PR DESCRIPTION
Previously the -N flag caused failure with LearnReaction.py. Error message "Too many values to unpack". Line 1705 under the getNeutralizing function was changed to return two empty lists. This change allowed LearnReactions.py to be run with the -N flag.

When the --plot flag was used on the cluster, the following error was returned: 
"RuntimeError('Invalid DISPLAY variable')"
"plt.switch_backend('agg')" was added after matplotlib is imported in order to fix this issue. Though if this script is intended more for use on workstations or personal computers, this change may not be needed.
